### PR TITLE
大佬，发现您的项目引入了org.apache.tika:tika-core@1.14组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.lxf</groupId>
@@ -65,7 +63,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.14</version>
+            <version>1.22</version>
         </dependency>
 
         <!--PDF解析包-->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Tika 缓冲区错误漏洞
缺陷组件：org.apache.tika:tika-core@1.14
漏洞编号：CVE-2019-10088
漏洞描述：Apache Tika是美国阿帕奇（Apache）软件基金会的一个集成了POI（使用Java程序对MicrosoftOffice格式文档提供读和写功能的开源函数库）、Pdfbox（读取和创建PDF文档的纯Java类库）并为文本抽取工作提供了统一界面的内容抽取工具集合。
Apache Tika 1.7版本至1.21版本中的RecursiveParserWrapper存在缓冲区错误漏洞。攻击者可利用该漏洞造成拒绝服务。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2019-27454
影响范围：[1.7, 1.22)
最小修复版本：1.22
缺陷组件引入路径：com.lxf:DocumentUtils@1.0->org.apache.tika:tika-core@1.14
```
另外我运行这个项目时，IDE的安全插件提示还有89个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p2e0ac